### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/nodalmechanics/lang/en_US.lang
+++ b/src/main/resources/assets/nodalmechanics/lang/en_US.lang
@@ -1,5 +1,6 @@
 itemGroup.nodalmechanics.tab=Nodal Mechanics
 
+item.nodalmechanics.matrix.name=Node Matrix
 item.nodalmechanics.matrix.attuned.name=Attuned Node Matrix
 item.nodalmechanics.matrix.unattuned.name=Unattuned Node Matrix
 tooltip.nodalmechanics.matrix.attuned=Faintly humming...


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.