### PR TITLE
Fix crashes and odd behavior from renamed Node Matricies 

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,3 +10,13 @@ dependencies {
 
     runtimeOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
 }
+
+project.getConfigurations()
+        .all(c -> {
+            final DependencySubstitutions ds = c.getResolutionStrategy()
+                    .getDependencySubstitution();
+            ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
+                    .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH"))
+                    .withClassifier("dev")
+                    .because("Baubles-Expanded replaces Baubles");
+        });

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,5 +8,5 @@ dependencies {
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
-    runtimeOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
+    runtimeOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
 }

--- a/src/main/java/shukaro/nodalmechanics/items/ItemMatrix.java
+++ b/src/main/java/shukaro/nodalmechanics/items/ItemMatrix.java
@@ -35,7 +35,7 @@ public class ItemMatrix extends Item {
         this.setMaxStackSize(1);
     }
 
-    public boolean isAttuned(ItemStack stack) {
+    public static boolean isAttuned(ItemStack stack) {
         return stack.hasTagCompound() && stack.getTagCompound().hasKey("Aspects");
     }
 

--- a/src/main/java/shukaro/nodalmechanics/items/ItemMatrix.java
+++ b/src/main/java/shukaro/nodalmechanics/items/ItemMatrix.java
@@ -35,13 +35,13 @@ public class ItemMatrix extends Item {
         this.setMaxStackSize(1);
     }
 
+    public boolean isAttuned(ItemStack stack) {
+        return stack.hasTagCompound() && stack.getTagCompound().hasKey("Aspects");
+    }
+
     @Override
     public String getUnlocalizedName(ItemStack stack) {
-        if (stack.hasTagCompound()) {
-            return this.getUnlocalizedName() + ".attuned";
-        } else {
-            return this.getUnlocalizedName() + ".unattuned";
-        }
+        return this.getUnlocalizedName() + (isAttuned(stack) ? ".attuned" : ".unattuned");
     }
 
     @Override
@@ -74,20 +74,20 @@ public class ItemMatrix extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public EnumRarity getRarity(ItemStack itemStack) {
-        return itemStack.hasTagCompound() ? EnumRarity.uncommon : EnumRarity.common;
+        return isAttuned(itemStack) ? EnumRarity.uncommon : EnumRarity.common;
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public boolean hasEffect(ItemStack itemStack, int pass) {
-        return itemStack.hasTagCompound();
+        return isAttuned(itemStack);
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("unchecked")
     public void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean advancedTooltips) {
-        if (itemStack.hasTagCompound()) {
+        if (isAttuned(itemStack)) {
             NBTTagCompound tagCompound = itemStack.getTagCompound();
             AspectList aspectList = new AspectList();
             aspectList.readFromNBT(tagCompound);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23641

~~**NOTE: This currently doesn't build! ForbiddenMagic needs to update from Baubles to BaublesExpanded, which appears to be waiting on**  https://github.com/GTNewHorizons/ForbiddenMagic/pull/23. I verified that this PR works by using mavenLocal and a fixed copy of ForbiddenMagic.~~
nevermind, i was gracefully supplied a fix (see comments of this pr)!

Before:
<img width="268" height="120" alt="image" src="https://github.com/user-attachments/assets/505f4199-4da1-4c00-a796-e06268c954a1" />
<img width="720" height="203" alt="image" src="https://github.com/user-attachments/assets/5a6e531e-ed09-42b1-9cb0-4a323785f6cf" />

After: (Note that it doesnt have the enchanted effect or weird name or crash)
<img width="501" height="136" alt="image" src="https://github.com/user-attachments/assets/78c7aaf0-efc2-4f8b-9b89-bfdf6f1fe632" />

