### PR TITLE
Minor cleanup. Remove excessive copies of the matrix recipe

### DIFF
--- a/src/main/java/shukaro/nodalmechanics/recipe/NodalRecipes.java
+++ b/src/main/java/shukaro/nodalmechanics/recipe/NodalRecipes.java
@@ -24,12 +24,10 @@ public class NodalRecipes {
     public static ShapedArcaneRecipe sameAttuneRecipe;
     public static InfusionRecipe variedNodeRecipe;
     public static InfusionRecipe sameNodeRecipe;
-    private ItemStack lapotronCrystal;
-    private ItemStack balancedShard;
 
     public NodalRecipes() {
-        lapotronCrystal = new ItemStack(Ic2Items.lapotronCrystal.getItem(), 1, OreDictionary.WILDCARD_VALUE);
-        balancedShard = ItemApi.getItem("itemShard", 6);
+        ItemStack lapotronCrystal = new ItemStack(Ic2Items.lapotronCrystal.getItem(), 1, OreDictionary.WILDCARD_VALUE);
+        ItemStack balancedShard = ItemApi.getItem("itemShard", 6);
         matrixRecipe = new InfusionRecipe(
                 "NODECATALYZATION",
                 new ItemStack(NodalItems.itemMatrix),

--- a/src/main/java/shukaro/nodalmechanics/recipe/NodalRecipes.java
+++ b/src/main/java/shukaro/nodalmechanics/recipe/NodalRecipes.java
@@ -25,12 +25,10 @@ public class NodalRecipes {
     public static InfusionRecipe variedNodeRecipe;
     public static InfusionRecipe sameNodeRecipe;
     private ItemStack lapotronCrystal;
-    private ArrayList<ItemStack> circuitAdvancedList;
     private ItemStack balancedShard;
 
     public NodalRecipes() {
         lapotronCrystal = new ItemStack(Ic2Items.lapotronCrystal.getItem(), 1, OreDictionary.WILDCARD_VALUE);
-        circuitAdvancedList = OreDictionary.getOres("circuitAdvanced");
         balancedShard = ItemApi.getItem("itemShard", 6);
         matrixRecipe = new InfusionRecipe(
                 "NODECATALYZATION",
@@ -135,18 +133,7 @@ public class NodalRecipes {
 
     @SuppressWarnings("unchecked")
     public void initRecipes() {
-        for (ItemStack circuitAdvanced : circuitAdvancedList) {
-            ThaumcraftApi.addInfusionCraftingRecipe(
-                    "NODECATALYZATION",
-                    new ItemStack(NodalItems.itemMatrix),
-                    10,
-                    new AspectList().add(DarkAspects.SLOTH, 16).add(DarkAspects.PRIDE, 16).add(Aspect.AURA, 32)
-                            .add(Aspect.MAGIC, 32),
-                    lapotronCrystal,
-                    new ItemStack[] { new ItemStack(ForbiddenItems.deadlyShards, 1, 3), balancedShard,
-                            new ItemStack(ForbiddenItems.deadlyShards, 1, 5), balancedShard,
-                            new ItemStack(ForbiddenItems.deadlyShards, 1, 5), balancedShard });
-        }
+        ThaumcraftApi.getCraftingRecipes().add(matrixRecipe);
         RecipeAttune recipeAttune = new RecipeAttune();
         ThaumcraftApi.getCraftingRecipes().add(recipeAttune);
         RecipeNode recipeNode = new RecipeNode();


### PR DESCRIPTION
Before the recipe change [commit](https://github.com/GTNewHorizons/Nodal-Mechanics/commit/acf8fb92db76b26389ed6cf15e54b51de3c235ef) nodal matrix had 4 multiple recipes. One per each variant of the HV circuit. That commit removed the circuit from the craft, but kept the foreach loop used to populate copies.

That creates identical pages in NEI and only increases confusion as NEI already tends to wrongly oredict shards.

This PR removes excessive copies and instead registers the same recipe that is already provided to the thaumonomicon.